### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,4 +1,7 @@
 name: labels
+permissions:
+  contents: read
+  issues: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/iiBamBlue/dependabot-devcard/security/code-scanning/1](https://github.com/iiBamBlue/dependabot-devcard/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job. The block should grant only the minimum required permissions. For a labeler action, this is typically `contents: read` (to read repository contents) and `issues: write` (to manage labels on issues and pull requests). The `permissions` block can be added at the workflow root (applies to all jobs) or at the job level (applies only to that job). The best practice is to add it at the workflow root unless different jobs require different permissions. In this case, since there is only one job, add the following at the top level, after the `name` field:

```yaml
permissions:
  contents: read
  issues: write
```

No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
